### PR TITLE
Add a conversion flag that sends tidy JSON to RabbitMQ

### DIFF
--- a/src/main/resources/fr/frogdevelopment/jenkins/plugins/mq/RabbitMqBuilder/config.jelly
+++ b/src/main/resources/fr/frogdevelopment/jenkins/plugins/mq/RabbitMqBuilder/config.jelly
@@ -23,4 +23,8 @@
         <f:checkbox />
     </f:entry>
 
+    <f:entry title="Escaped string" field="conversion">
+            <f:checkbox default="true"/>
+    </f:entry>
+
 </j:jelly>

--- a/src/main/resources/fr/frogdevelopment/jenkins/plugins/mq/RabbitMqBuilder/help-conversion.html
+++ b/src/main/resources/fr/frogdevelopment/jenkins/plugins/mq/RabbitMqBuilder/help-conversion.html
@@ -1,0 +1,7 @@
+<div>
+    if checked, there will be Spring escaping . It is especially important with Json formatting .
+    <ul>
+        <li>if Checked, the message is  "{\"step\":\"end\"}"</li>
+        <li>if unchecked, the message is {"step":"end"}</li>
+    </ul>
+</div>

--- a/src/test/java/fr/frogdevelopment/jenkins/plugins/mq/RabbitMqBuilderTest.java
+++ b/src/test/java/fr/frogdevelopment/jenkins/plugins/mq/RabbitMqBuilderTest.java
@@ -48,6 +48,7 @@ public class RabbitMqBuilderTest {
         String routingKey = "test-routingKey";
         String parameters = "test-parameters";
         boolean isToJson = true;
+        boolean conversion = true;
 
         // RABBIT CONFIG
         ArrayList<RabbitConfig> rabbitConfigs = new ArrayList<>();
@@ -56,6 +57,7 @@ public class RabbitMqBuilderTest {
         RabbitMqBuilder rabbitMqBuilder = new RabbitMqBuilder(rabbitName, exchange, parameters);
         rabbitMqBuilder.setRoutingKey(routingKey);
         rabbitMqBuilder.setToJson(isToJson);
+        rabbitMqBuilder.setConversion(conversion);
         Configs configs = new Configs(rabbitConfigs);
         RabbitMqDescriptor descriptor = rabbitMqBuilder.getDescriptor();
         descriptor.setConfigs(configs);
@@ -66,6 +68,7 @@ public class RabbitMqBuilderTest {
         Assertions.assertThat(rabbitMqBuilder.getRoutingKey()).isEqualTo(routingKey);
         Assertions.assertThat(rabbitMqBuilder.getData()).isEqualTo(parameters);
         Assertions.assertThat(rabbitMqBuilder.isToJson()).isEqualTo(isToJson);
+        Assertions.assertThat(rabbitMqBuilder.getConversion()).isEqualTo(conversion);
 
         ListBoxModel listBoxModel = descriptor.doFillRabbitNameItems();
         Assertions.assertThat(listBoxModel).hasSameSizeAs(rabbitConfigs);


### PR DESCRIPTION
Currently, the message sent to RabbitMQ is :
* surrounded by ""
* the " is escaped in \"

The commit add a flag "conversion" that allows to disable this conversion and have plain JSON