### PR TITLE
Have a better compatibility with old Jenkins (tested back to 2.73)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <jenkins.version>2.164</jenkins.version>
+        <jenkins.version>2.73</jenkins.version>
         <jenkins-test-harness.version>2.34</jenkins-test-harness.version>
 
         <findbugs-maven-plugin.version>3.0.5</findbugs-maven-plugin.version>

--- a/src/main/java/fr/frogdevelopment/jenkins/plugins/mq/RabbitMqBuilder.java
+++ b/src/main/java/fr/frogdevelopment/jenkins/plugins/mq/RabbitMqBuilder.java
@@ -446,7 +446,7 @@ public class RabbitMqBuilder extends Builder implements SimpleBuildStep {
                                                    @QueryParameter("isSecure") final String isSecure,
                                                    @QueryParameter("virtualHost") final String virtualHost) {
                 // https://jenkins.io/doc/developer/security/form-validation/
-                Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+                Jenkins.getActiveInstance().checkPermission(Jenkins.ADMINISTER); // Keep this deprecated method for compatibility with old jenkins
 
                 try {
                     ConnectionFactory connectionFactory = RabbitMqFactory.createConnectionFactory(


### PR DESCRIPTION
* We need to use Jenkins.getActiveInstance() method as the Jenkins.get() was added in Jenkins 2.98
* There is no jenkins jar in the hpi file so we don't embark old Jenkins code with security issues